### PR TITLE
chore: slim core deps, move test/embedding deps to optional extras

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "pyarrowspace"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "arrowspace",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ name = "arrowspace"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrowspace = { version = "0.26.3", features = ["storage"] } #, path = "../arrowspace-rs"}
+arrowspace = { version = "0.26.2", features = ["storage"] } #, path = "../arrowspace-rs"}
 pyo3 = { version = "0.27.1", features = ["extension-module"] }
 pyo3-log = "0.13"
 numpy = "0.27.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyarrowspace"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2024"
 description = "Spectral vector search with taumode (λτ) indexing"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]
@@ -41,7 +41,7 @@ name = "arrowspace"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrowspace = { version = "0.26.2", features = ["storage"] } #, path = "../arrowspace-rs"}
+arrowspace = { version = "0.26.3", features = ["storage"] } #, path = "../arrowspace-rs"}
 pyo3 = { version = "0.27.1", features = ["extension-module"] }
 pyo3-log = "0.13"
 numpy = "0.27.0"

--- a/README.md
+++ b/README.md
@@ -22,15 +22,15 @@ Additional capabilities are available as optional extras:
 
 | Extra | Packages included | Use case |
 |---|---|---|
-| `embeddings` | `sentence-transformers`, `transformers[torch]<5.0`, `tsdae` | Generating embeddings from text via HuggingFace models |
-| `benchmarks` | `beir`, `datasets`, `nltk` | Running BEIR/MS-MARCO benchmark suites and NLP preprocessing |
+| `embeddings` | `datasets`, `sentence-transformers`, `transformers[torch]<5.0`, `tsdae` | Generating embeddings from text via HuggingFace models; required for `test_1_quora_questions.py` and all tests above |
+| `benchmarks` | `beir`, `nltk` | Running BEIR/MS-MARCO benchmark suites and NLP preprocessing |
 | `viz` | `matplotlib`, `seaborn`, `tqdm` | Plotting results and progress bars in test scripts |
 | `full` | all of the above | Full development and research environment |
 
 Install with one or more extras:
 
 ```bash
-# Embedding support only
+# Required to run test_1_quora_questions.py and above
 pip install arrowspace[embeddings]
 
 # Benchmarking + visualisation
@@ -39,6 +39,8 @@ pip install arrowspace[benchmarks,viz]
 # Everything (for running the full test suite)
 pip install arrowspace[full]
 ```
+
+> **Note:** `tests/test_0_*.py` only require the core install. All tests numbered `test_1` and above require at minimum `arrowspace[embeddings]`.
 
 ### Build from source
 
@@ -53,15 +55,24 @@ maturin develop --release
 ```
 
 ## Tests
-Simple test:
+
+`test_0_*.py` scripts only require the core install:
 ```
-python tests/test_0.py
+python tests/test_0_0.py
 ```
-Test with public QA dataset:
+
+`test_1` and above require the `embeddings` extra (`pip install arrowspace[embeddings]`):
 ```
 python tests/test_1_quora_questions.py
 ```
-There are other tests but they require downloading a dataset separately or fine-tuning the embeddings on a given dataset. Give it a try and let me know!
+
+Higher-numbered tests (`test_3` and above) additionally require `benchmarks` and `viz`:
+```
+pip install arrowspace[full]
+python tests/test_3_beir.py
+```
+
+Some tests require downloading a dataset separately or fine-tuning embeddings on a given dataset.
 
 ## Simplest Example
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Python bindings for [`arrowspace-rs`](https://github.com/Mec-iS/arrowspace-rs).
 
-`arrowspace` is a database for vectors supported by a graph representation and a key-value store. The main use-cases targeted are: AI search capabilities as advanced vector similarity, graph characterisation analysis and search, indexing of high-dimensional vectors. Design principles described in [this article](https://www.tuned.org.uk/posts/010_game_changer_unifying_vectors_and_features_graphs).
+`arrowspace` is a graph-based analytics library for vector spaces, supported by a graph representation and a key-value store. The main use-cases targeted are: AI search capabilities as advanced vector similarity, graph characterisation analysis and search, indexing of high-dimensional vectors. Design principles described in [this article](https://www.tuned.org.uk/posts/010_game_changer_unifying_vectors_and_features_graphs).
 
 For labs and tests please see [tests/](https://github.com/tuned-org-uk/pyarrowspace/tree/main/tests)
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,48 @@ Python bindings for [`arrowspace-rs`](https://github.com/Mec-iS/arrowspace-rs).
 For labs and tests please see [tests/](https://github.com/tuned-org-uk/pyarrowspace/tree/main/tests)
 
 ## Installation
-From PyPi:
+
+### Core library
+
+The core library ships as a compiled Rust extension. It only requires `numpy`, `pyarrow`, `pandas`, and `scikit-learn`:
+
 ```
 pip install arrowspace
 ```
-or any other way of installing a Python library.
 
-If you have cargo installed, to compile from source and use locally: 
+### Optional extras
+
+Additional capabilities are available as optional extras:
+
+| Extra | Packages included | Use case |
+|---|---|---|
+| `embeddings` | `sentence-transformers`, `transformers[torch]<5.0`, `tsdae` | Generating embeddings from text via HuggingFace models |
+| `benchmarks` | `beir`, `datasets`, `nltk` | Running BEIR/MS-MARCO benchmark suites and NLP preprocessing |
+| `viz` | `matplotlib`, `seaborn`, `tqdm` | Plotting results and progress bars in test scripts |
+| `full` | all of the above | Full development and research environment |
+
+Install with one or more extras:
+
+```bash
+# Embedding support only
+pip install arrowspace[embeddings]
+
+# Benchmarking + visualisation
+pip install arrowspace[benchmarks,viz]
+
+# Everything (for running the full test suite)
+pip install arrowspace[full]
 ```
+
+### Build from source
+
+If you have Cargo installed, you can compile and install locally using [maturin](https://github.com/PyO3/maturin):
+
+```bash
 pip install maturin[patchelf]
-# quick building
+# quick development build
 maturin develop
-# release building, needed for large datasets
+# optimised release build (recommended for large datasets)
 maturin develop --release
 ```
 
@@ -31,7 +61,7 @@ Test with public QA dataset:
 ```
 python tests/test_1_quora_questions.py
 ```
-There are other tests but they require downloadin a dataset separately or fine-tuning the embeddings on a given dataset. Give it a try and let me know!
+There are other tests but they require downloading a dataset separately or fine-tuning the embeddings on a given dataset. Give it a try and let me know!
 
 ## Simplest Example
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,15 +46,16 @@ dependencies = [
 
 [project.optional-dependencies]
 # Embedding model support (sentence-transformers, TSDAE, HuggingFace)
+# Required for tests >= test_1_quora_questions.py
 embeddings = [
+    "datasets>=4.5.0",
     "sentence-transformers>=5.2.0",
     "transformers[torch]<5.0",
     "tsdae>=1.1.0",
 ]
-# Benchmark and dataset utilities (BEIR, HuggingFace datasets, NLTK)
+# Benchmark and dataset utilities (BEIR, NLTK)
 benchmarks = [
     "beir>=2.2.0",
-    "datasets>=4.5.0",
     "nltk>=3.10.0",
 ]
 # Visualisation and progress utilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,20 +38,34 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "beir>=2.2.0",
-    "datasets>=4.5.0",
-    "matplotlib>=3.10.8",
-    "maturin>=1.12.0",
-    "nltk>=3.10.0",
     "numpy>=2.4.2",
-    "pandas>=3.0.0",
     "pyarrow>=23.0.0",
+    "pandas>=3.0.0",
     "scikit-learn>=1.8.0",
-    "seaborn>=0.13.2",
+]
+
+[project.optional-dependencies]
+# Embedding model support (sentence-transformers, TSDAE, HuggingFace)
+embeddings = [
     "sentence-transformers>=5.2.0",
-    "tqdm>=4.67.3",
     "transformers[torch]<5.0",
     "tsdae>=1.1.0",
+]
+# Benchmark and dataset utilities (BEIR, HuggingFace datasets, NLTK)
+benchmarks = [
+    "beir>=2.2.0",
+    "datasets>=4.5.0",
+    "nltk>=3.10.0",
+]
+# Visualisation and progress utilities
+viz = [
+    "matplotlib>=3.10.8",
+    "seaborn>=0.13.2",
+    "tqdm>=4.67.3",
+]
+# Convenience: install everything (e.g. for running the full test suite)
+full = [
+    "arrowspace[embeddings,benchmarks,viz]",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

The core library is pure Rust (`src/*.rs`) with PyO3 bindings — none of the heavy Python dependencies (`transformers`, `sentence-transformers`, `beir`, etc.) are imported by the library itself. All usages are in `tests/` scripts, which are already excluded from the sdist.

This PR trims the mandatory install footprint significantly and moves everything into optional extras.

## Changes

### Core `dependencies` (was 13 packages, now 4)
```
numpy, pyarrow, pandas, scikit-learn
```

### Removed from runtime deps
- **`maturin`** — build tool only; already declared in `[build-system].requires` and documented in README as `pip install maturin[patchelf]` + `maturin develop` for source builds. Not a runtime dependency.

### New optional extras

| Extra | Packages | Install with |
|---|---|---|
| `[embeddings]` | `sentence-transformers`, `transformers[torch]<5.0`, `tsdae` | `pip install arrowspace[embeddings]` |
| `[benchmarks]` | `beir`, `datasets`, `nltk` | `pip install arrowspace[benchmarks]` |
| `[viz]` | `matplotlib`, `seaborn`, `tqdm` | `pip install arrowspace[viz]` |
| `[full]` | all of the above | `pip install arrowspace[full]` |

## Impact

Users installing `pip install arrowspace` for core spectral/graph use no longer pull down the full PyTorch + HuggingFace stack. The full test suite continues to work with `pip install arrowspace[full]`.