### PR TITLE
fix(#25,#17): API ergonomics + persistence addressing; bump arrowspace 0.26.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "arrowspace"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8854034eed4290a067f5c00cd385a1838cec22ddd64aefd886c484fc37972b6"
+checksum = "2235b219b2c0d8b4a22db8e0e979d63bc19e39a0c0645fecc870b98514985800"
 dependencies = [
  "approx 0.5.1",
  "arrow",
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "pyarrowspace"
-version = "0.26.4"
+version = "0.26.5"
 dependencies = [
  "arrowspace",
  "numpy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pyarrowspace"
-version = "0.26.4"
+version = "0.26.5"
 edition = "2024"
 description = "Spectral vector search with taumode (λτ) indexing"
 authors = ["Lorenzo <tunedconsulting@gmail.com>"]
@@ -41,7 +41,7 @@ name = "arrowspace"
 crate-type = ["cdylib"]
 
 [dependencies]
-arrowspace = { version = "0.26.4", features = ["storage"] } #, path = "../arrowspace-rs"}
+arrowspace = { version = "0.26.5", features = ["storage"] } #, path = "../arrowspace-rs"}
 pyo3 = { version = "0.27.1", features = ["extension-module"] }
 pyo3-log = "0.13"
 numpy = "0.27.0"

--- a/pytest-tests/test_graph_params_unknown_keys.py
+++ b/pytest-tests/test_graph_params_unknown_keys.py
@@ -1,0 +1,46 @@
+"""Tests for #25 item 2: unknown / misspelled `graph_params` keys must raise
+`TypeError` rather than be silently ignored (the same failure family as #23's
+silent float-drop).
+
+A typo like `top_k` instead of `topk` currently falls back to the default
+`topk=3`, silently producing a different index than configured. The parser
+should reject unrecognised keys listing the offenders.
+"""
+import numpy as np
+import pytest
+
+from arrowspace import ArrowSpaceBuilder
+
+
+def _items():
+    items = np.random.default_rng(0).standard_normal((60, 24))
+    items /= np.linalg.norm(items, axis=1, keepdims=True)
+    return items
+
+
+def test_misspelled_top_k_raises():
+    items = _items()
+    gp = {"eps": 0.5, "k": 10, "top_k": 9, "p": 2.0, "sigma": None}  # top_k typo
+    with pytest.raises(TypeError):
+        ArrowSpaceBuilder().with_seed(42).build(gp, items)
+
+
+def test_bogus_key_raises():
+    items = _items()
+    gp = {"eps": 0.5, "k": 10, "topk": 9, "p": 2.0, "sigma": None, "bogus_param": 123}
+    with pytest.raises(TypeError):
+        ArrowSpaceBuilder().with_seed(42).build(gp, items)
+
+
+def test_error_message_lists_unknown_key():
+    items = _items()
+    gp = {"eps": 0.5, "k": 10, "bogus": 1}
+    with pytest.raises(TypeError, match="bogus"):
+        ArrowSpaceBuilder().with_seed(42).build(gp, items)
+
+
+def test_known_keys_still_accepted():
+    items = _items()
+    gp = {"eps": 0.5, "k": 10, "topk": 5, "p": 2.0, "sigma": 0.05}
+    _, gl = ArrowSpaceBuilder().with_seed(42).build(gp, items)  # must not raise
+    assert gl.graph_params["topk"] == 5

--- a/pytest-tests/test_persistence_roundtrip.py
+++ b/pytest-tests/test_persistence_roundtrip.py
@@ -1,0 +1,74 @@
+"""Tests for #25 item 5 / #17: persistence must be addressable so a built index
+can be reloaded after a process/container restart.
+
+#17 documents three stacked bugs: `with_persistence` is not exposed to Python,
+`build_and_store` writes to a hardcoded CWD/`storage` path with a random UUID
+name the caller never sees, and the reload path looks in a different location.
+#25 item 5 is the narrower addressing gap in the method that does persist today.
+
+These tests pin the round-trip contract:
+  * `with_persistence(path, dataset_name)` is exposed on the builder,
+  * `build_and_store(graph_params, items, path=None, dataset_name=None)` accepts
+    explicit addressing and surfaces the resolved `(storage_path, dataset_name)`
+    on the returned objects so the caller can reload its own artifacts,
+  * a built index round-trips through `load_arrowspace`.
+"""
+import inspect
+import numpy as np
+import pytest
+
+from arrowspace import ArrowSpaceBuilder, load_arrowspace
+
+
+@pytest.fixture
+def items():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((40, 16))
+    x /= np.linalg.norm(x, axis=1, keepdims=True)
+    return x
+
+
+GP = {"eps": 0.5, "k": 8, "topk": 4, "p": 2.0, "sigma": None}
+
+
+def test_builder_exposes_with_persistence():
+    assert hasattr(ArrowSpaceBuilder(), "with_persistence")
+
+
+def test_build_and_store_accepts_path_and_dataset_name():
+    sig = inspect.signature(ArrowSpaceBuilder().build_and_store)
+    assert "storage_path" in sig.parameters, f"build_and_store has no storage_path: {sig}"
+    assert "dataset_name" in sig.parameters, f"build_and_store has no dataset_name: {sig}"
+
+
+def test_build_and_store_surfaces_resolved_addressing(tmp_path, items):
+    a, gl = (
+        ArrowSpaceBuilder().with_seed(42).build_and_store(
+            GP, items, storage_path=str(tmp_path), dataset_name="roundtrip_test"
+        )
+    )
+    # the resolved name must be visible to the caller so reload is possible
+    assert getattr(a, "dataset_name", None) == "roundtrip_test"
+    assert str(tmp_path) in getattr(a, "storage_path", "")
+
+
+def test_build_and_store_then_load_roundtrips(tmp_path, items):
+    a, gl = ArrowSpaceBuilder().with_seed(42).build_and_store(
+        GP, items, storage_path=str(tmp_path), dataset_name="rt"
+    )
+    a2, gl2 = load_arrowspace(str(tmp_path), "rt", GP, False)
+    assert a2.nitems == a.nitems
+    assert a2.nfeatures == a.nfeatures
+
+
+def test_with_persistence_then_build_roundtrips(tmp_path, items):
+    """The #17 Option A path: expose with_persistence, build() writes, reload reads."""
+    a, gl = (
+        ArrowSpaceBuilder()
+        .with_seed(42)
+        .with_persistence(str(tmp_path), "persist_test")
+        .build(GP, items)
+    )
+    a2, gl2 = load_arrowspace(str(tmp_path), "persist_test", GP, False)
+    assert a2.nitems == a.nitems
+    assert a2.nfeatures == a.nfeatures

--- a/pytest-tests/test_search_batch_partial.py
+++ b/pytest-tests/test_search_batch_partial.py
@@ -1,0 +1,73 @@
+"""Tests for #25 item 1: `search_batch` must not abort the entire batch when a
+single row is degenerate (lambda = 0).
+
+Previously a degenerate row caused `return Err(...)`, discarding all already-
+scored rows — unusable for whole-corpus work where ~1 row is typically
+degenerate. The new contract returns `list[list[(idx, score)] | None]`: `None`
+for degenerate rows, results for the rest. The single-query `search` still
+raises (correct — it is the batch semantics that need partial-failure
+tolerance).
+"""
+import numpy as np
+import pytest
+
+from arrowspace import ArrowSpaceBuilder
+
+
+@pytest.fixture(scope="module")
+def normal_index():
+    items = np.random.default_rng(0).standard_normal((120, 48))
+    items /= np.linalg.norm(items, axis=1, keepdims=True)
+    a, gl = (
+        ArrowSpaceBuilder().with_seed(42)
+        .with_dims_reduction(False, None)
+        .with_sampling("simple", 1.0)
+    ).build({"eps": 1.29, "k": 29, "topk": 14, "p": 2.0, "sigma": None}, items)
+    return a, gl, items
+
+
+def test_batch_with_one_degenerate_row_returns_none_for_that_row_only(normal_index):
+    a, gl, items = normal_index
+    # row 1 is the zero-vector -> degenerate; rows 0 and 2 are valid
+    batch = np.vstack([items[0], np.zeros(48), items[1]])
+    results = a.search_batch(batch, gl, 0.55)
+    assert len(results) == 3
+    assert results[0] is not None, "valid row 0 was dropped"
+    assert results[1] is None, "degenerate row 1 should be None, not raise"
+    assert results[2] is not None, "valid row 2 was dropped"
+    assert len(results[0]) > 0
+
+
+def test_batch_all_valid_returns_no_none(normal_index):
+    a, gl, items = normal_index
+    results = a.search_batch(items[:10], gl, 0.55)
+    assert len(results) == 10
+    assert all(r is not None for r in results)
+
+
+def test_batch_all_degenerate_returns_all_none():
+    deg = np.array([[1., 0., 0., 0.], [-1., 0., 0., 0.], [0., 1., 0., 0.]])
+    deg /= np.linalg.norm(deg, axis=1, keepdims=True)
+    a, gl = ArrowSpaceBuilder().with_seed(42).build(
+        {"eps": 1.29, "k": 2, "topk": 3, "p": 2.0, "sigma": None}, deg
+    )
+    results = a.search_batch(deg, gl, 0.55)
+    assert len(results) == 3
+    assert results == [None, None, None]
+
+
+def test_batch_degenerate_row_does_not_discard_already_scored_rows(normal_index):
+    """The issue's core complaint: 823 scored rows thrown away because row 824
+    was degenerate. Verify a degenerate row in position 0 does not abort the
+    rest, and one in the last position keeps the earlier results."""
+    a, gl, items = normal_index
+    # degenerate first, then 4 valid
+    batch = np.vstack([np.zeros(48), items[0], items[1], items[2], items[3]])
+    results = a.search_batch(batch, gl, 0.55)
+    assert results[0] is None
+    assert all(r is not None for r in results[1:])
+    # degenerate last, after 4 valid
+    batch2 = np.vstack([items[0], items[1], items[2], items[3], np.zeros(48)])
+    results2 = a.search_batch(batch2, gl, 0.55)
+    assert all(r is not None for r in results2[:4])
+    assert results2[4] is None

--- a/pytest-tests/test_search_error_boundary.py
+++ b/pytest-tests/test_search_error_boundary.py
@@ -1,0 +1,64 @@
+"""Tests for #25 item 4: Rust panics must not cross the FFI boundary as
+PanicException. `search` should raise a typed, catchable `ValueError`
+(documented by the existing guard at lib.rs:246) instead of the upstream
+`prepare_query_item` panic.
+
+The upstream `arrowspace 0.26.5` added `try_prepare_query_item` returning
+`Result<f64, ArrowSpaceError>` precisely so FFI bindings can surface catchable
+exceptions; these tests pin that the binding uses it.
+"""
+import numpy as np
+import pytest
+
+from arrowspace import ArrowSpaceBuilder
+
+
+@pytest.fixture(scope="module")
+def degenerate_index():
+    """3-item corpus where every lambda is ~0 (mis-tuned eps)."""
+    deg = np.array([[1., 0., 0., 0.], [-1., 0., 0., 0.], [0., 1., 0., 0.]])
+    deg /= np.linalg.norm(deg, axis=1, keepdims=True)
+    a, gl = ArrowSpaceBuilder().with_seed(42).build(
+        {"eps": 1.29, "k": 2, "topk": 3, "p": 2.0, "sigma": None}, deg
+    )
+    return a, gl, deg
+
+
+def test_search_on_degenerate_query_raises_value_error_not_panic(degenerate_index):
+    a, gl, deg = degenerate_index
+    with pytest.raises(ValueError):
+        a.search(deg[0], gl, 0.55)
+
+
+def test_search_degenerate_error_message_mentions_eps(degenerate_index):
+    a, gl, deg = degenerate_index
+    with pytest.raises(ValueError, match="eps"):
+        a.search(deg[0], gl, 0.55)
+
+
+def test_search_zero_vector_query_raises_value_error():
+    """A zero-vector query is degenerate against a normal index too."""
+    items = np.random.default_rng(0).standard_normal((120, 48))
+    items /= np.linalg.norm(items, axis=1, keepdims=True)
+    a, gl = (
+        ArrowSpaceBuilder().with_seed(42)
+        .with_dims_reduction(False, None)
+        .with_sampling("simple", 1.0)
+    ).build({"eps": 1.29, "k": 29, "topk": 14, "p": 2.0, "sigma": None}, items)
+    with pytest.raises(ValueError):
+        a.search(np.zeros(48), gl, 0.55)
+
+
+def test_search_non_finite_query_raises_value_error():
+    """NaN in the query should raise ValueError, not panic."""
+    items = np.random.default_rng(0).standard_normal((120, 48))
+    items /= np.linalg.norm(items, axis=1, keepdims=True)
+    a, gl = (
+        ArrowSpaceBuilder().with_seed(42)
+        .with_dims_reduction(False, None)
+        .with_sampling("simple", 1.0)
+    ).build({"eps": 1.29, "k": 29, "topk": 14, "p": 2.0, "sigma": None}, items)
+    q = items[0].copy()
+    q[0] = np.nan
+    with pytest.raises(ValueError):
+        a.search(q, gl, 0.55)

--- a/pytest-tests/test_search_k_override.py
+++ b/pytest-tests/test_search_k_override.py
@@ -1,0 +1,59 @@
+"""Tests for #25 item 3: `search` / `search_batch` should accept an optional
+`k` override so the number of retrieved neighbours can change without
+rebuilding the index (which conflates the construction hyperparameter `topk`
+with the retrieval parameter `k`).
+
+New signature: `search(item, gl, tau, k=None)` / `search_batch(items, gl, tau,
+k=None)`, defaulting to `graph_params.topk`. Backwards compatible.
+"""
+import inspect
+import numpy as np
+import pytest
+
+from arrowspace import ArrowSpaceBuilder
+
+
+@pytest.fixture(scope="module")
+def normal_index():
+    items = np.random.default_rng(0).standard_normal((120, 48))
+    items /= np.linalg.norm(items, axis=1, keepdims=True)
+    a, gl = (
+        ArrowSpaceBuilder().with_seed(42)
+        .with_dims_reduction(False, None)
+        .with_sampling("simple", 1.0)
+    ).build({"eps": 1.29, "k": 29, "topk": 14, "p": 2.0, "sigma": None}, items)
+    return a, gl, items
+
+
+def test_search_accepts_k_kwarg(normal_index):
+    a, gl, items = normal_index
+    sig = inspect.signature(a.search)
+    assert "k" in sig.parameters, f"search has no k parameter: {sig}"
+
+
+def test_search_batch_accepts_k_kwarg(normal_index):
+    a, gl, items = normal_index
+    sig = inspect.signature(a.search_batch)
+    assert "k" in sig.parameters, f"search_batch has no k parameter: {sig}"
+
+
+def test_search_k_override_changes_result_count(normal_index):
+    a, gl, items = normal_index
+    default = a.search(items[0], gl, 0.55)
+    fewer = a.search(items[0], gl, 0.55, k=5)
+    assert len(fewer) <= 5
+    assert len(fewer) != len(default) or len(default) <= 5
+
+
+def test_search_k_none_defaults_to_topk(normal_index):
+    a, gl, items = normal_index
+    explicit_none = a.search(items[0], gl, 0.55, k=None)
+    default = a.search(items[0], gl, 0.55)
+    assert explicit_none == default
+
+
+def test_search_batch_k_override_applies_to_all_rows(normal_index):
+    a, gl, items = normal_index
+    results = a.search_batch(items[:4], gl, 0.55, k=3)
+    assert all(r is not None for r in results)
+    assert all(len(r) <= 3 for r in results)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -66,10 +66,33 @@ pub(crate) fn extract_count(v: &Bound<'_, PyAny>, scope: &str, field: &str) -> P
 /// floats (e.g. `29.0`) are accepted and coerced for `k`/`topk`; non-integral
 /// floats (`29.5`) raise. `eps` and `p` are extracted as `f64` and accept
 /// floats natively.
+///
+/// **Unknown keys raise `TypeError`** listing the offenders — a typo like
+/// `top_k` instead of `topk` no longer silently falls back to the default
+/// (#25 item 2). The accepted keys are: `eps`, `k`, `topk`, `p`, `sigma`.
 pub fn parse_graph_params(dict_opt: Option<&Bound<'_, PyDict>>) -> PyResult<Option<(f64, usize, usize, f64, Option<f64>)>> {
     let Some(d) = dict_opt else {
         return Ok(None);
     };
+
+    // Reject unknown / misspelled keys up front — same failure family as the
+    // silent float-drop fixed in #23. A typo'd `top_k` previously fell back to
+    // the default `topk=3`, silently producing a different index.
+    const KNOWN: &[&str] = &["eps", "k", "topk", "p", "sigma"];
+    let mut unknown: Vec<String> = Vec::new();
+    for key in d.keys() {
+        let key_str: String = key.extract().unwrap_or_default();
+        if !KNOWN.contains(&key_str.as_str()) {
+            unknown.push(key_str);
+        }
+    }
+    if !unknown.is_empty() {
+        return Err(PyTypeError::new_err(format!(
+            "graph_params: unknown key(s) {} — accepted keys are {:?}",
+            unknown.iter().map(|s| format!("'{}'", s)).collect::<Vec<_>>().join(", "),
+            KNOWN
+        )));
+    }
 
     let eps = match d.get_item("eps")? {
         Some(v) => v.extract::<f64>()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(non_local_definitions)]
 use ::arrowspace::maps::energymaps::{EnergyMaps, EnergyMapsBuilder};
 use ::arrowspace::sampling::SamplerType;
-use pyo3::exceptions::PyValueError;
+use pyo3::exceptions::{PyOSError, PyTypeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyTuple};
 use smartcore::linalg::basic::arrays::Array;
@@ -9,6 +9,7 @@ use smartcore::linalg::basic::arrays::Array;
 use numpy::{PyArray1, PyArray2, PyArrayMethods, PyReadonlyArray1, PyReadonlyArray2};
 use ::arrowspace::builder::ArrowSpaceBuilder as RustBuilder;
 use ::arrowspace::core::{ArrowItem, ArrowSpace};
+use ::arrowspace::error::ArrowSpaceError;
 use ::arrowspace::graph::GraphLaplacian;
 use ::arrowspace::analysis::motives::Motives;
 use ::arrowspace::analysis::subgraphs::*;
@@ -29,6 +30,24 @@ mod tests;
 mod tests_python;
 
 use std::path::PathBuf;
+
+/// Map a fallible `ArrowSpaceError` from `try_prepare_query_item` to a typed,
+/// catchable Python exception — never a `PanicException` (#25 item 4).
+///
+/// `DegenerateLambda` → `ValueError` (the guard `lib.rs` already wanted to
+/// raise), `NonFiniteQuery` → `ValueError`, `DimensionMismatch` → `ValueError`.
+fn map_arrow_error(e: ArrowSpaceError) -> PyErr {
+    match e {
+        ArrowSpaceError::DegenerateLambda { .. } => {
+            PyValueError::new_err(format!("{}", e))
+        }
+        ArrowSpaceError::NonFiniteQuery => PyValueError::new_err(format!("{}", e)),
+        ArrowSpaceError::DimensionMismatch { .. } => {
+            PyValueError::new_err(format!("{}", e))
+        }
+        ArrowSpaceError::EmptyItems => PyValueError::new_err(format!("{}", e)),
+    }
+}
 
 fn get_python_cwd(py: Python) -> PyResult<PathBuf> {
     // Import the 'os' module
@@ -62,6 +81,8 @@ pub fn init() {
 #[pyclass(name = "GraphLaplacian")]
 pub struct PyGraphLaplacian {
     inner: GraphLaplacian,
+    storage_path: Option<String>,
+    dataset_name: Option<String>,
 }
 
 #[pymethods]
@@ -76,6 +97,26 @@ impl PyGraphLaplacian {
     #[getter]
     fn nnodes(&self) -> usize {
         self.inner.nnodes
+    }
+
+    /// Resolved persistence directory set by `build_and_store` / `with_persistence`
+    /// builds (None for in-memory builds). See #25 item 5 / #17.
+    #[getter]
+    fn storage_path<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        match &self.storage_path {
+            Some(s) => Ok(s.into_pyobject(py)?.into_any()),
+            None => Ok(py.None().into_bound(py).into_any()),
+        }
+    }
+
+    /// Resolved dataset name set by `build_and_store` / `with_persistence` builds
+    /// (None for in-memory builds). Required by `load_arrowspace`.
+    #[getter]
+    fn dataset_name<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        match &self.dataset_name {
+            Some(s) => Ok(s.into_pyobject(py)?.into_any()),
+            None => Ok(py.None().into_bound(py).into_any()),
+        }
     }
 
     fn shape(&self) -> (usize, usize) {
@@ -151,6 +192,10 @@ impl PyGraphLaplacian {
 #[pyclass(name = "ArrowSpace")]
 pub struct PyArrowSpace {
     inner: ArrowSpace,
+    /// Resolved persistence addressing set by `build_and_store` / `with_persistence`
+    /// builds, so the caller can reload its own artifacts (#25 item 5 / #17).
+    storage_path: Option<String>,
+    dataset_name: Option<String>,
 }
 
 #[pymethods]
@@ -170,6 +215,27 @@ impl PyArrowSpace {
     #[getter]
     fn nfeatures(&self) -> usize {
         self.inner.nfeatures
+    }
+
+    /// Resolved persistence directory set by `build_and_store` / `with_persistence`
+    /// builds (None for in-memory builds). Lets the caller reload its own
+    /// artifacts without guessing — see #25 item 5 / #17.
+    #[getter]
+    fn storage_path<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        match &self.storage_path {
+            Some(s) => Ok(s.into_pyobject(py)?.into_any()),
+            None => Ok(py.None().into_bound(py).into_any()),
+        }
+    }
+
+    /// Resolved dataset name set by `build_and_store` / `with_persistence` builds
+    /// (None for in-memory builds). Required by `load_arrowspace`.
+    #[getter]
+    fn dataset_name<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        match &self.dataset_name {
+            Some(s) => Ok(s.into_pyobject(py)?.into_any()),
+            None => Ok(py.None().into_bound(py).into_any()),
+        }
     }
 
     #[getter]
@@ -223,49 +289,60 @@ impl PyArrowSpace {
         Ok(arr.reshape(shape)?)
     }
 
-    /// taumode search using eigenmaps (use build)
+    /// taumode search using eigenmaps (use build).
+    ///
+    /// `k` overrides the number of retrieved neighbours (defaults to the index's
+    /// `topk`). Passing `k=None` keeps the build-time `topk`. Separating the
+    /// retrieval `k` from the construction `topk` avoids rebuilding the whole
+    /// index for k-sweep experiments — see #25 item 3.
+    ///
+    /// Raises `ValueError` (not `PanicException`) for degenerate queries
+    /// (lambda ~0), non-finite queries, or dimension mismatch — see #25 item 4.
+    #[pyo3(signature = (item, gl, tau, k=None))]
     fn search(
         &self,
         item: PyReadonlyArray1<f64>,
         gl: &PyGraphLaplacian,
         tau: f64,
+        k: Option<usize>,
     ) -> PyResult<Vec<(usize, f64)>> {
         let v = item.as_slice()?;
-        
-        if v.len() != self.inner.nfeatures {
-            return Err(PyValueError::new_err(format!(
-                "query length {} must match nfeatures {}",
-                v.len(),
-                self.inner.nfeatures
-            )));
-        }
 
         let graph_laplacian = &gl.inner;
-        let lambda_q = self.inner.prepare_query_item(v, graph_laplacian);
-
-        if lambda_q == 0.0 {
-            return Err(PyValueError::new_err(
-                "Lambda is zero - check item magnitude and eps parameter"
-            ));
-        }
+        // Fallible variant: surface a typed ValueError instead of letting the
+        // upstream panic cross the FFI as an opaque PanicException (#25 item 4).
+        let lambda_q = self
+            .inner
+            .try_prepare_query_item(v, graph_laplacian)
+            .map_err(map_arrow_error)?;
 
         dbg_println(format!("search: qlen={}, lambda_q={:.6}", v.len(), lambda_q));
 
         let query = ArrowItem::new(v, lambda_q);
-        let k = graph_laplacian.graph_params.topk;
+        let k = k.unwrap_or(graph_laplacian.graph_params.topk);
 
         Ok(self.inner.search_lambda_aware(&query, k, tau))
     }
 
+    /// Batch taumode search. Degenerate rows (lambda ~0) yield `None` in that
+    /// slot instead of aborting the whole batch — partial-failure tolerant, so
+    /// whole-corpus work survives a single bad row. Valid rows are never
+    /// discarded because of a later degenerate one. See #25 item 1.
+    ///
+    /// `k` overrides the retrieved-neighbour count (defaults to `topk`). See
+    /// `search`. Non-finite or dimension-mismatched batches still raise (those
+    /// are caller bugs affecting every row, not per-row degeneracy).
+    #[pyo3(signature = (items, gl, tau, k=None))]
     fn search_batch(
         &self,
         items: PyReadonlyArray2<f64>,
         gl: &PyGraphLaplacian,
         tau: f64,
-    ) -> PyResult<Vec<Vec<(usize, f64)>>> {
+        k: Option<usize>,
+    ) -> PyResult<Vec<Option<Vec<(usize, f64)>>>> {
         let arr = items.as_array();
         let (nqueries, nfeatures) = (arr.shape()[0], arr.shape()[1]);
-        
+
         if nfeatures != self.inner.nfeatures {
             return Err(PyValueError::new_err(format!(
                 "query features {} must match nfeatures {}",
@@ -274,29 +351,32 @@ impl PyArrowSpace {
         }
 
         let graph_laplacian = &gl.inner;
-        let k = graph_laplacian.graph_params.topk;
-        
-        let mut results = Vec::with_capacity(nqueries);
-        
+        let k = k.unwrap_or(graph_laplacian.graph_params.topk);
+
+        let mut results: Vec<Option<Vec<(usize, f64)>>> = Vec::with_capacity(nqueries);
+
         for i in 0..nqueries {
             let row = arr.row(i);
             let v = row.to_slice().unwrap();
-            
-            let lambda_q = self.inner.prepare_query_item(v, graph_laplacian);
-            if lambda_q == 0.0 {
-                return Err(PyValueError::new_err(format!(
-                    "Lambda is zero for query {} - check item magnitude and eps", i
-                )));
+
+            match self.inner.try_prepare_query_item(v, graph_laplacian) {
+                Ok(lambda_q) => {
+                    let query = ArrowItem::new(v, lambda_q);
+                    results.push(Some(self.inner.search_lambda_aware(&query, k, tau)));
+                }
+                Err(ArrowSpaceError::DegenerateLambda { .. }) => {
+                    // Skip this row, keep the rest of the batch.
+                    results.push(None);
+                }
+                Err(e) => return Err(map_arrow_error(e)),
             }
-            
-            let query = ArrowItem::new(v, lambda_q);
-            results.push(self.inner.search_lambda_aware(&query, k, tau));
         }
-        
+
         Ok(results)
     }
 
-    /// taumode hybrid search using eigenmaps (use build): cosine + energy
+    /// taumode hybrid search using eigenmaps (use build): cosine + energy.
+    /// Raises `ValueError` for degenerate/non-finite/mismatched queries (#25 item 4).
     fn search_hybrid(
         &self,
         item: PyReadonlyArray1<f64>,
@@ -304,17 +384,12 @@ impl PyArrowSpace {
         tau: f64,
     ) -> PyResult<Vec<(usize, f64)>> {
         let v = item.as_slice()?;
-        
-        if v.len() != self.inner.nfeatures {
-            return Err(PyValueError::new_err(format!(
-                "query length {} must match nfeatures {}",
-                v.len(),
-                self.inner.nfeatures
-            )));
-        }
 
         let graph_laplacian = &gl.inner;
-        let lambda_q = self.inner.prepare_query_item(v, graph_laplacian);
+        let lambda_q = self
+            .inner
+            .try_prepare_query_item(v, graph_laplacian)
+            .map_err(map_arrow_error)?;
 
         dbg_println(format!("search_hybrid: qlen={}, lambda_q={:.6}", v.len(), lambda_q));
 
@@ -493,6 +568,11 @@ impl PyArrowSpace {
 #[pyclass(name = "ArrowSpaceBuilder")]
 pub struct PyArrowSpaceBuilder {
     pub(crate) inner: RustBuilder,
+    /// Tracking copy of persistence addressing (dataset_name, storage_path) set
+    /// via `with_persistence`, so `build()` can surface it on the returned
+    /// objects. `RustBuilder.persistence` is `pub(crate)` in the upstream crate
+    /// and therefore not readable here.
+    persistence_info: Option<(String, String)>,
 }
 
 #[pymethods]
@@ -501,6 +581,7 @@ impl PyArrowSpaceBuilder {
     pub fn new() -> Self {
         Self {
             inner: RustBuilder::new(),
+            persistence_info: None,
         }
     }
     
@@ -519,6 +600,30 @@ impl PyArrowSpaceBuilder {
         slf
     }
     
+    /// Set persistence addressing so `build(...)` writes Parquet files the caller
+    /// can later reload via `load_arrowspace`. Without this, `build()` is
+    /// in-memory only and `build_and_store()` picks a random unaddressable name.
+    ///
+    /// Exposed to Python for #17 (Option A): the adapter can now call
+    /// `with_persistence(settings.index_store, slug)` so the write and reload
+    /// paths agree on `dataset_name` and base directory, instead of the
+    /// hardcoded CWD/`storage` + UUID that `build_and_store` used to generate.
+    ///
+    /// The resolved `(storage_path, dataset_name)` are surfaced as attributes on
+    /// the returned `ArrowSpace` / `GraphLaplacian`.
+    pub fn with_persistence(
+        mut slf: PyRefMut<Self>,
+        storage_path: String,
+        dataset_name: String,
+    ) -> PyRefMut<Self> {
+        slf.persistence_info = Some((dataset_name.clone(), storage_path.clone()));
+        slf.inner = slf
+            .inner
+            .clone()
+            .with_persistence(PathBuf::from(&storage_path), dataset_name);
+        slf
+    }
+
     /// set sampling type and percentage
     pub fn with_sampling<'a>(mut slf: PyRefMut<'a, Self>, sampling: Option<&str>, value: Option<f64>) -> PyResult<PyRefMut<'a, Self>> {
         if sampling.is_some() || value.is_some() {
@@ -603,6 +708,7 @@ impl PyArrowSpaceBuilder {
         };
 
         let mut builder = slf.inner.clone();
+        let persist_info = slf.persistence_info.clone();
         
         if let Some((eps, k, topk, p, sigma)) = parse_graph_params(graph_params)? {
             builder = builder
@@ -622,24 +728,49 @@ impl PyArrowSpaceBuilder {
             (aspace, gl)
         });
 
+        let (storage_path, dataset_name) = match persist_info {
+            Some((name, path)) => (Some(path), Some(name)),
+            None => (None, None),
+        };
         Ok((
-            Py::new(py, PyArrowSpace { inner: aspace })?,
-            Py::new(py, PyGraphLaplacian { inner: gl })?,
+            Py::new(py, PyArrowSpace {
+                inner: aspace,
+                storage_path: storage_path.clone(),
+                dataset_name: dataset_name.clone(),
+            })?,
+            Py::new(py, PyGraphLaplacian {
+                inner: gl,
+                storage_path,
+                dataset_name,
+            })?,
         ))
     }
 
-    /// Same as `build(...)` but save computations on parquet files
+    /// Same as `build(...)` but save computations on parquet files.
+    ///
+    /// `storage_path` / `dataset_name` make the write addressable so the caller
+    /// can reload its own artifacts via `load_arrowspace` — previously the name
+    /// was a random `dataset_<uuid>` surfaced only via `dbg_println`, and the
+    /// path was a hardcoded CWD/`storage` (#25 item 5, #17). When omitted, the
+    /// legacy behaviour (CWD/`storage`, random UUID) is preserved for backwards
+    /// compatibility.
+    ///
+    /// The resolved `(storage_path, dataset_name)` are exposed as attributes on
+    /// the returned `ArrowSpace` / `GraphLaplacian`.
+    #[pyo3(signature = (graph_params, items, storage_path=None, dataset_name=None))]
     pub fn build_and_store(
         slf: PyRefMut<Self>,
         py: Python<'_>,
         graph_params: Option<&Bound<'_, PyDict>>,
         items: PyReadonlyArray2<f64>,
+        storage_path: Option<String>,
+        dataset_name: Option<String>,
     ) -> PyResult<(Py<PyArrowSpace>, Py<PyGraphLaplacian>)> {
         dbg_println("build: Converting numpy array to internal format");
-        
+
         let arr = items.as_array();
         let (nrows, ncols) = (arr.shape()[0], arr.shape()[1]);
-        
+
         let rows: Vec<Vec<f64>> = if nrows > 1000 {
             use rayon::prelude::*;
             (0..nrows)
@@ -652,30 +783,41 @@ impl PyArrowSpaceBuilder {
                 .collect()
         };
 
-        let uuid = get_uid(py)?;
-        let dataset_name = format!("dataset_{}", uuid);
-        let cwd = get_python_cwd(py)?;
-        
-        let dir_path = cwd.join("storage");
+        let dir_path = match &storage_path {
+            Some(p) => PathBuf::from(p),
+            None => {
+                // Legacy default: CWD/storage
+                let cwd = get_python_cwd(py)?;
+                cwd.join("storage")
+            }
+        };
+        let dataset_name = match dataset_name {
+            Some(n) => n,
+            None => format!("dataset_{}", get_uid(py)?),
+        };
 
         use std::fs;
         dbg_println(format!("Creating directory at: {:?}", dir_path.canonicalize().unwrap_or(dir_path.clone())));
-        fs::create_dir_all(&dir_path).expect("Failed to create directory");
-        dbg_println(format!("build: Storing in path {:?}", dir_path));
-        
+        // Raise a catchable OSError instead of panicking across the FFI when the
+        // target directory is not writable (#25 item 4 minor).
+        fs::create_dir_all(&dir_path).map_err(|e| {
+            PyOSError::new_err(format!("Failed to create storage directory {:?}: {}", dir_path, e))
+        })?;
+        dbg_println(format!("build: Storing in path {:?} as {}", dir_path, dataset_name));
+
         let mut builder = slf.inner.clone();
-        
+
         if let Some((eps, k, topk, p, sigma)) = parse_graph_params(graph_params)? {
             builder = builder
                 .with_lambda_graph(eps, k, topk, p, sigma)
                 .with_sparsity_check(false)
-                .with_persistence(dir_path, dataset_name);
+                .with_persistence(dir_path.clone(), dataset_name.clone());
         }
 
         dbg_println(format!("build: Processing {} rows × {} cols", nrows, ncols));
         let (aspace, gl) = py.detach(|| {
             let (aspace, gl) = builder.build(rows);
-            
+
             dbg_println(format!(
                 "build complete: nitems={}, nfeatures={}, lambdas={}",
                 aspace.nitems, aspace.nfeatures, aspace.lambdas().len()
@@ -684,9 +826,18 @@ impl PyArrowSpaceBuilder {
             (aspace, gl)
         });
 
+        let storage_path_str = dir_path.to_string_lossy().to_string();
         Ok((
-            Py::new(py, PyArrowSpace { inner: aspace })?,
-            Py::new(py, PyGraphLaplacian { inner: gl })?,
+            Py::new(py, PyArrowSpace {
+                inner: aspace,
+                storage_path: Some(storage_path_str.clone()),
+                dataset_name: Some(dataset_name.clone()),
+            })?,
+            Py::new(py, PyGraphLaplacian {
+                inner: gl,
+                storage_path: Some(storage_path_str),
+                dataset_name: Some(dataset_name),
+            })?,
         ))
     }
 
@@ -739,8 +890,8 @@ impl PyArrowSpaceBuilder {
         });
 
         Ok((
-            Py::new(py, PyArrowSpace { inner: aspace })?,
-            Py::new(py, PyGraphLaplacian { inner: gl })?,
+            Py::new(py, PyArrowSpace { inner: aspace, storage_path: None, dataset_name: None })?,
+            Py::new(py, PyGraphLaplacian { inner: gl, storage_path: None, dataset_name: None })?,
         ))
     }
 
@@ -799,8 +950,8 @@ impl PyArrowSpaceBuilder {
         });
 
         Ok((
-            Py::new(py, PyArrowSpace { inner: aspace })?,
-            Py::new(py, PyGraphLaplacian { inner: gl_energy })?,
+            Py::new(py, PyArrowSpace { inner: aspace, storage_path: None, dataset_name: None })?,
+            Py::new(py, PyGraphLaplacian { inner: gl_energy, storage_path: None, dataset_name: None })?,
         ))
     }
 }
@@ -845,7 +996,9 @@ pub fn load_arrowspace(
     let g_params = if let Some((eps, k, topk, p, sigma)) = params_tuple {
         GraphParams { eps, k, topk, p, sigma, sparsity_check: false, normalise: false }
     } else {
-        panic!("Cannot parse GraphParams");
+        return Err(PyValueError::new_err(
+            "Cannot parse GraphParams: graph_params dict is required for load_arrowspace"
+        ));
     };
 
     dbg_println(format!("GraphParams {:?}", g_params));
@@ -868,8 +1021,16 @@ pub fn load_arrowspace(
     ));
 
     Ok((
-        Py::new(py, PyArrowSpace { inner: aspace })?,
-        Py::new(py, PyGraphLaplacian { inner: gl })?,
+        Py::new(py, PyArrowSpace {
+            inner: aspace,
+            storage_path: Some(storage_path.clone()),
+            dataset_name: Some(dataset_name.clone()),
+        })?,
+        Py::new(py, PyGraphLaplacian {
+            inner: gl,
+            storage_path: Some(storage_path),
+            dataset_name: Some(dataset_name),
+        })?,
     ))
 }
 

--- a/tests/test_0_3_subgraphs.py
+++ b/tests/test_0_3_subgraphs.py
@@ -65,7 +65,7 @@ builder = (
 )
 
 # Build using ONLY the data matrix
-aspace, gl = builder.build(dict(eps=0.8, k=10, topk=8, p=2.0, sigma_override=None), items)
+aspace, gl = builder.build(dict(eps=0.8, k=10, topk=8, p=2.0, sigma=None), items)
 
 print(f"\nbuild complete: nitems={aspace.nitems}, nfeatures={aspace.nfeatures}, lambdas={len(aspace.lambdas())}")
 print(f"ArrowSpace built: nitems={aspace.nitems}, centroids={gl.nnodes}")

--- a/tests/test_0_7.py
+++ b/tests/test_0_7.py
@@ -1,12 +1,39 @@
+"""Persistence round-trip: build an index to a known address, then reload it.
+
+Previously build_and_store picked a random `dataset_<uuid>` name the caller
+never saw, so reload had to guess which file was theirs (issue #17). With
+the storage_path/dataset_name kwargs, the write and reload paths agree.
+"""
 from pathlib import Path
-from arrowspace import load_arrowspace
+import numpy as np
+from arrowspace import ArrowSpaceBuilder, load_arrowspace
 
 graph_params = {"eps": 0.97, "k": 21, "topk": 10, "p": 2.0, "sigma": 0.1}
 
-print(f"Loading ArrowSpace from storage")
-aspace, gl = load_arrowspace(
-    storage_path=str(Path(__file__).parent.parent / "storage/"),
-    dataset_name="dataset_858414",   # pick one dataset in storage/
+storage = Path(__file__).parent.parent / "storage"
+storage.mkdir(exist_ok=True)
+
+items = np.random.default_rng(42).standard_normal((40, 16))
+items /= np.linalg.norm(items, axis=1, keepdims=True)
+
+print("Building and storing ArrowSpace with explicit dataset_name...")
+aspace, gl = ArrowSpaceBuilder().with_seed(42).build_and_store(
+    graph_params, items.astype(np.float64),
+    storage_path=str(storage), dataset_name="test_0_7_index",
+)
+print(f"  stored: {aspace.dataset_name} at {aspace.storage_path}")
+assert aspace.dataset_name == "test_0_7_index"
+assert aspace.nitems == 40
+
+print("Reloading ArrowSpace from storage...")
+aspace2, gl2 = load_arrowspace(
+    storage_path=str(storage),
+    dataset_name="test_0_7_index",
     graph_params=graph_params,
     energy=False,
 )
+print(f"  reloaded: {aspace2.nitems} items × {aspace2.nfeatures} features")
+assert aspace2.nitems == aspace.nitems
+assert aspace2.nfeatures == aspace.nfeatures
+
+print("Round-trip OK")


### PR DESCRIPTION
## Summary

Addresses issue #25 (6 API papercuts) and issue #17 (persist/reload broken), bumping the `arrowspace` Rust dependency to `0.26.5` which added the `try_prepare_query_item` / `ArrowSpaceError` API and `degenerate_lambda_count()` specifically so FFI bindings can surface catchable exceptions.

Developed TDD: 20 RED tests written first against the buggy `0.26.4` behaviour, all now GREEN; 45 pytest-tests total pass, 8 legacy experiment scripts pass.

## Changes by issue item

### #25 item 4 — Rust panics must not cross FFI as PanicException
`search`, `search_hybrid`, `search_batch` now use `try_prepare_query_item` (new in arrowspace 0.26.5) and map `ArrowSpaceError` to `ValueError` via `map_arrow_error`. Degenerate/non-finite/mismatched queries raise a catchable `ValueError` instead of an opaque `PanicException` with a Rust backtrace. `load_arrowspace`'s `panic!("Cannot parse GraphParams")` replaced with `PyValueError`; `build_and_store`'s `fs::create_dir_all().expect()` replaced with `PyOSError`. (The build-time "N of M lambdas are ~0" warning is upstream in 0.26.5.)

### #25 item 1 — search_batch aborts the whole batch on one degenerate row
`search_batch` now returns `list[list[(idx, score)] | None]`: degenerate rows (lambda=0) yield `None` in that slot; valid rows are never discarded. Whole-corpus work survives a single bad row. The single-query `search` still raises (correct — batch semantics need partial-failure tolerance).

### #25 item 3 — search/search_batch cannot override k
New signature: `search(item, gl, tau, k=None)` / `search_batch(items, gl, tau, k=None)`, defaulting to `graph_params.topk`. Separates the retrieval `k` from the construction `topk` so k-sweep experiments don't rebuild the index per k. Backwards compatible via `#[pyo3(signature = (..., k=None))]`.

### #25 item 2 — unknown graph_params keys silently ignored
`parse_graph_params` now rejects unknown/misspelled keys with `TypeError` listing the offenders. A typo `top_k` instead of `topk` no longer silently falls back to the default `topk=3` (same failure family as #23's silent float-drop).

### #25 item 5 / #17 — persistence addressing
- `with_persistence(path, dataset_name)` exposed on the builder (#17 Option A).
- `build_and_store(graph_params, items, storage_path=None, dataset_name=None)` accepts explicit addressing; when omitted, legacy behaviour (CWD/storage, random UUID) is preserved. The resolved `(storage_path, dataset_name)` are surfaced as attributes on the returned `ArrowSpace` / `GraphLaplacian` so the caller can reload its own artifacts.
- `build()` surfaces addressing when `with_persistence` was set.
- `load_arrowspace` sets the addressing attributes on returned objects.

### #25 item 6 (minor) — not addressed in this PR
`py.typed`/stubs and `nnodes` naming are documentation ergonomics; deferred to keep this PR scoped to the correctness bugs.

## Version bump
`pyarrowspace` 0.26.4 to 0.26.5; `arrowspace` Rust dep 0.26.4 to 0.26.5 (API compatible — the `try_prepare_query_item`/`ArrowSpaceError`/`degenerate_lambda_count` additions are the upstream half of item 4).

## Tests
- `pytest-tests/test_search_error_boundary.py` (4) — item 4: ValueError not PanicException
- `pytest-tests/test_search_batch_partial.py` (4) — item 1: degenerate row to None, valid rows kept
- `pytest-tests/test_search_k_override.py` (5) — item 3: k override + None default
- `pytest-tests/test_graph_params_unknown_keys.py` (4) — item 2: unknown keys raise
- `pytest-tests/test_persistence_roundtrip.py` (5) — item 5/#17: build_and_store + with_persistence round-trip
- Existing `test_parse_graph_params.py` (9) + `test_parse_motives_config.py` (14) still pass
- Legacy: `test_0_3` fixed (`sigma_override` typo to `sigma`); `test_0_7` rewritten as a round-trip demonstrating the #17 fix

Closes #25. Closes #17.
